### PR TITLE
Add forceLocal define to allow loading locally

### DIFF
--- a/src/lime/_internal/backend/html5/HTML5HTTPRequest.hx
+++ b/src/lime/_internal/backend/html5/HTML5HTTPRequest.hx
@@ -42,7 +42,7 @@ class HTML5HTTPRequest {
 
 	public function new () {
 
-		validStatus0 = ~/Tizen/gi.match (Browser.window.navigator.userAgent);
+		validStatus0 = #if forceLocal true #else ~/Tizen/gi.match (Browser.window.navigator.userAgent) #end;
 
 	}
 


### PR DESCRIPTION
Compiling with -DforceLocal allow files to be served locally when browser supports this.
Use case : Cordova use a webview and many files can't be loaded without allowing http status 0 as successful.